### PR TITLE
Fix NPE created by ConsoleInterceptor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,12 @@
+import com.mainstreethub.jenkins.pipelines.Notifier
+import com.mainstreethub.jenkins.pipelines.java.library.Pipeline
+
+def notifier = new Notifier([
+  steps: this,
+  ownerChannels: ["infrastructure-notify"]
+])
+
+new Pipeline(this).run([
+  notifier: notifier,
+  isOpenSource: true
+])

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>dropwizard-json-log-bundle</artifactId>
-  <version>1.0.2-1-SNAPSHOT</version>
+  <version>1.1.4-1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>dropwizard-json-log-bundle</name>
@@ -24,9 +24,9 @@
   </licenses>
 
   <scm>
-    <url>http://github.com/mainstreethub/dropwizard-json-log-bundle</url>
-    <connection>scm:git:git@github.com:mainstreethub/dropwizard-json-log-bundle.git</connection>
-    <developerConnection>scm:git:git@github.com:mainstreethub/dropwizard-json-log-bundle.git
+    <url>https://github.com/mainstreethub/dropwizard-json-log-bundle</url>
+    <connection>scm:git:https://github.com/mainstreethub/dropwizard-json-log-bundle.git</connection>
+    <developerConnection>scm:git:https://github.com/mainstreethub/dropwizard-json-log-bundle.git
     </developerConnection>
     <tag>HEAD</tag>
   </scm>

--- a/src/test/java/io/dropwizard/bundles/jsonlog/test/ConsoleInterceptor.java
+++ b/src/test/java/io/dropwizard/bundles/jsonlog/test/ConsoleInterceptor.java
@@ -9,12 +9,22 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 import org.junit.rules.ExternalResource;
 
+/**
+ * Interceptor which will capture any messages written to the console to test assertions against.
+ */
 public class ConsoleInterceptor extends ExternalResource {
+  private final PrintStream current;
+
   private List<String> logs = new CopyOnWriteArrayList<>();
+
+  public ConsoleInterceptor() {
+    current = System.out;
+    assert current != null;
+  }
 
   @Override
   protected void before() throws Throwable {
-    System.setOut(new PrintStream(System.out) {
+    final PrintStream out = new PrintStream(current) {
       @Override
       public void write(byte[] b) throws IOException {
         logs.add(new String(b));
@@ -27,7 +37,9 @@ public class ConsoleInterceptor extends ExternalResource {
 
         super.write(buf, off, len);
       }
-    });
+    };
+
+    System.setOut(out);
   }
 
   public Callable<Boolean> contains(Predicate<String> test) {
@@ -40,6 +52,6 @@ public class ConsoleInterceptor extends ExternalResource {
 
   @Override
   protected void after() {
-    System.setOut(null);
+    System.setOut(current);
   }
 }


### PR DESCRIPTION
The ConsoleInterceptor was causing NPEs in tests that ran after it. Re-configure out in the after instead of setting to `null`.

Additionally,  add support for running in a Jenkins Pipeline.