### PR TITLE
Enable logging of remote_user in access logs [HUBP-203]

### DIFF
--- a/src/main/java/io/dropwizard/bundles/jsonlog/JsonRequestLogFactory.java
+++ b/src/main/java/io/dropwizard/bundles/jsonlog/JsonRequestLogFactory.java
@@ -80,6 +80,7 @@ public class JsonRequestLogFactory
     fieldNames.setFieldsStatusCode(fields.getStatusCode().orElse(null));
     fieldNames.setFieldsHostname(fields.getHostname().orElse(null));
     fieldNames.setFieldsRequestedUrl(fields.getRequestedUrl().orElse(null));
+    fieldNames.setFieldsRemoteUser(fields.getRemoteUser().orElse(null));
     fieldNames.setMessage(fields.getMessage());
     encoder.setFieldNames(fieldNames);
 
@@ -107,6 +108,7 @@ public class JsonRequestLogFactory
     private String method = "verb";
     private String protocol = "protocol";
     private String remoteHost = "source_host";
+    private String remoteUser = "remote_user";
     private String requestedUri = "request";
     private String statusCode = "response";
     private String hostname = null;
@@ -137,6 +139,11 @@ public class JsonRequestLogFactory
     @JsonProperty
     public void setRemoteHost(String remoteHost) {
       this.remoteHost = remoteHost;
+    }
+
+    @JsonProperty
+    public void setRemoteUser(String remoteUser) {
+      this.remoteUser = remoteUser;
     }
 
     @JsonProperty
@@ -172,6 +179,11 @@ public class JsonRequestLogFactory
     @JsonProperty
     public Optional<String> getRemoteHost() {
       return Optional.ofNullable(remoteHost);
+    }
+
+    @JsonProperty
+    public Optional<String> getRemoteUser() {
+      return Optional.ofNullable(remoteUser);
     }
 
     @JsonProperty


### PR DESCRIPTION
mainstreethub/msh-dropwizard-auth-bundle@216516e7 added support for
logging the authenticated user in the access logs.  By default, logback
logs the remote user in a json field called "@fields.remote_user" which
logstash is unable to process.  This updates the field name for remote_user
to be a logstash valid name.